### PR TITLE
Appropriately get the branch

### DIFF
--- a/lib/heroku_san/tasks.rb
+++ b/lib/heroku_san/tasks.rb
@@ -109,7 +109,7 @@ end
 desc "Deploys, migrates and restarts latest code"
 task :deploy => :before_deploy do
   each_heroku_app do |name, app, repo|
-    branch = `git branch`.scan(/^\* (.*)\n/).to_s
+    branch = `git branch`.scan(/^\* (.*)\n/).flatten.first.to_s
     if branch.present?
       @git_push_arguments ||= []
       system_with_echo "git push #{repo} #{@git_push_arguments.join(' ')} #{branch}:master && heroku rake --app #{app} db:migrate && heroku restart --app #{app}"


### PR DESCRIPTION
In ruby 1.9, Array#to_s behaves differently than in 1.8. It doesn't returns the first element as a string.
But a real representation of the array as a string. So the branch names becomes `[['master']]`

With a `.flatten.first.to_s`, this fixes the problem.
