### PR TITLE
Rake::Task[:deploy].invoke instead of execute 

### DIFF
--- a/lib/heroku_san/tasks.rb
+++ b/lib/heroku_san/tasks.rb
@@ -144,7 +144,7 @@ namespace :deploy do
   task :force, :commit do |t, args|
     @git_push_arguments ||= []
     @git_push_arguments << '--force'
-    Rake::Task[:deploy].execute(args)
+    Rake::Task[:deploy].invoke(args)
   end
 end
 


### PR DESCRIPTION
Nevermind on the last pull request.  Calling invoke instead of execute here should invoke the prerequisites (i.e., before_deploy).
