### PR TITLE
Include deployed named rev in app info.

### DIFF
--- a/lib/heroku_san/tasks.rb
+++ b/lib/heroku_san/tasks.rb
@@ -82,8 +82,15 @@ namespace :heroku do
   desc 'Lists configured apps'
   task :apps => :all do
     each_heroku_app do |name, app, repo|
-      puts "#{name} is shorthand for the Heroku app #{app} located at:"
-      puts "  #{repo}"
+      puts  "#{name} is shorthand for the Heroku app #{app} located at:"
+      puts  "  #{repo}"
+      print "  @ "
+      rev = `git ls-remote -h #{repo}`.split(' ').first
+      if rev.blank?
+        puts 'not deployed'
+      else
+        puts `git name-rev #{rev}`
+      end
       puts
     end
   end


### PR DESCRIPTION
Hi, I wrote a small portion of heroku_san myself before discovering your solution which is obviously far superior.

But the one thing I didn't see was a way to show the deployed revs, so I added it.

It looks like this (sha is intentionally broken here to avoid github trying to linkify it):

```
> rake heroku:apps
(in /Users/mat/code/dailymoji)
production is shorthand for the Heroku app cramscreen located at:
  git@heroku.com:cramscreen.git
  @ not deployed

staging is shorthand for the Heroku app dailymoji-staging located at:
  git@heroku.com:dailymoji-staging.git
  @ f.03c7226b7eb95c7907f3011c6ea25091022432f master
```

Seems to work for me, and I avoided my original awk/pipe implementation which should keep it windows compatible, but if have any thoughts on testing please let me know. Or if you'd rather a different formatting, that'd be cool too.

Thanks!
