### PR TITLE
Use the current branch as the application name

### DIFF
--- a/lib/heroku_san/tasks.rb
+++ b/lib/heroku_san/tasks.rb
@@ -246,11 +246,22 @@ namespace :db do
 end
 
 def each_heroku_app
-  if @heroku_apps.blank? && @app_settings.keys.size == 1
-    app = @app_settings.keys.first
-    puts "Defaulting to #{app} app since only one app is defined"
-    @heroku_apps = [app]
+  if @heroku_apps.blank? 
+    if @app_settings.keys.size == 1
+      app = @app_settings.keys.first
+      puts "Defaulting to #{app} app since only one app is defined"
+      @heroku_apps = [app]
+    else
+      @app_settings.keys.each do |key|
+        active_branch = %x{git branch}.split("\n").select { |b| b =~ /^\*/ }.first.split(" ").last.strip
+        if key == active_branch
+          puts "Defaulting to #{key} as it matches the current branch"
+          @heroku_apps = [key]
+        end
+      end
+    end
   end
+
   if @heroku_apps.present?
     @heroku_apps.each do |name|
       app = @app_settings[name]['app']


### PR DESCRIPTION
My applications tend to have a branch for each Heroku environment, so that I can selectively pull features from master and deploy them.

This patch allows heroku_san to pick up which application it should be acting on based on the branch name. If the shorthand name matches the current branch then the assumption will be made that it is the application you want to perform actions on.

That allows me to do something like this:

```
git checkout staging
git rebase master
rake deploy
```

And helps to make sure I don't accidentally deploy the master branch to the production server.
