### PR TITLE
Avoid rake 0.9.0 task syntax deprecation warning.

### DIFF
--- a/lib/heroku_san/tasks.rb
+++ b/lib/heroku_san/tasks.rb
@@ -226,7 +226,7 @@ namespace :heroku do
 end
 
 desc "Pushes the given commit, migrates and restarts (default: HEAD)"
-task :deploy, :commit, :needs => :before_deploy do |t, args|
+task :deploy, [:commit] => [:before_deploy] do |t, args|
   each_heroku_app do |name, app, repo|
     push(args[:commit], repo)
     migrate(app)


### PR DESCRIPTION
Looks like this:
    WARNING: 'task :t, arg, :needs => [deps]' is deprecated.  Please use 'task :t, [args] => [deps]' instead.
        at /Users/mat/.rvm/gems/ruby-1.9.2-p180/bundler/gems/heroku_san-19d603ee32a6/lib/heroku_san/tasks.rb:229:in `<top (required)>'
