### PR TITLE
Remove deprecation warnings caused by rake updates

### DIFF
--- a/lib/heroku_san/tasks.rb
+++ b/lib/heroku_san/tasks.rb
@@ -226,7 +226,7 @@ namespace :heroku do
 end
 
 desc "Pushes the given commit, migrates and restarts (default: HEAD)"
-task :deploy, :commit, :needs => :before_deploy do |t, args|
+task :deploy, [:commit] => :before_deploy do |t, args|
   each_heroku_app do |name, app, repo|
     push(args[:commit], repo)
     migrate(app)


### PR DESCRIPTION
Remove deprecation warning 'Please use 'task :t, [args] => [deps]' instead.'
