### PR TITLE
Cedar compatibility (updated)

### DIFF
--- a/heroku_san.gemspec
+++ b/heroku_san.gemspec
@@ -2,11 +2,11 @@
 
 Gem::Specification.new do |s|
   s.name = %q{heroku_san}
-  s.version = "1.2.0"
+  s.version = "1.2.2"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
-  s.authors = ["Elijah Miller", "Glenn Roberts"]
-  s.date = %q{2011-03-14}
+  s.authors = ["Elijah Miller", "Glenn Roberts", "Ryan Ahearn"]
+  s.date = %q{2011-06-16}
   s.description = %q{Manage multiple Heroku instances/apps for a single Rails app using Rake}
   s.email = %q{elijah.miller@gmail.com}
   s.homepage = %q{http://github.com/glennr/heroku_san}
@@ -22,19 +22,19 @@ Gem::Specification.new do |s|
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<rails>, ['>= 2'])
-      s.add_runtime_dependency(%q<heroku>)
+      s.add_runtime_dependency(%q<heroku>, ['>= 2'])
       s.add_development_dependency(%q<rails>, ['>= 3'])
       s.add_development_dependency(%q<aruba>)
       s.add_development_dependency(%q<cucumber>)
     else
       s.add_dependency(%q<rails>, ['>= 2'])
-      s.add_dependency(%q<heroku>)
+      s.add_dependency(%q<heroku>, ['>= 2'])
       s.add_dependency(%q<aruba>)
       s.add_dependency(%q<cucumber>)
     end
   else
     s.add_dependency(%q<rails>, ['>= 2'])
-    s.add_dependency(%q<heroku>)
+    s.add_dependency(%q<heroku>, ['>= 2'])
     s.add_dependency(%q<aruba>)
     s.add_dependency(%q<cucumber>)
   end

--- a/lib/templates/heroku.example.yml
+++ b/lib/templates/heroku.example.yml
@@ -3,16 +3,19 @@
 # 
 # <heroku_san shorthand name>:
 #   app: <Heroku app name>
+#   stack: <Heroku stack, optional>
 #   config:
 #     - <Heroku config:var name>: <Heroku config:var value>
 #
 production: 
   app: awesomeapp
+  stack: bamboo-ree-1.8.7
   config:
     BUNDLE_WITHOUT: "development:test"
     GOOGLE_ANALYTICS: "UA-12345678-1"
 
 staging:
+  stack: cedar
   app: awesomeapp-staging
   config: &default
     BUNDLE_WITHOUT: "development:test"


### PR DESCRIPTION
Compatibility with cedar stack. Specify optional stack in config file; if present, will be used in `rake heroku:create`.

New and improved version of https://github.com/fastestforward/heroku_san/pull/55
