### PR TITLE
Upcase ENV names, and allow whitespace in ENV values

### DIFF
--- a/lib/heroku_san/tasks.rb
+++ b/lib/heroku_san/tasks.rb
@@ -165,7 +165,7 @@ namespace :heroku do
     each_heroku_app do |name, app, repo, config|
       command = "heroku config:add --app #{app}"
       config.each do |var, value|
-        command += " #{var}=#{value}"
+        command += " #{var.upcase}='#{value}'"
       end
       sh(command)
     end


### PR DESCRIPTION
Hi,

1) Uppercase ENV/config vars on Heroku to follow Unix (and Heroku) convention regardless of the case used in the config file.

2) Allow whitespace in ENV/config var values.

(And a little cleanup commit).
