### PR TITLE
Optionally override app repo url.

### DIFF
--- a/lib/heroku_san/tasks.rb
+++ b/lib/heroku_san/tasks.rb
@@ -353,7 +353,12 @@ def each_heroku_app
       app = @app_settings[name]['app']
       config = @app_settings[name]['config'] || {}
       config.merge!(@extra_config[name]) if (@extra_config && @extra_config[name])
-      yield(name, app, "git@heroku.com:#{app}.git", config)
+      if @app_settings[name].has_key? 'repo'
+        repo = @app_settings[name]['repo']
+      else
+        repo = "git@heroku.com:#{app}.git"
+      end
+      yield(name, app, repo, config)
     end
     puts
   else


### PR DESCRIPTION
If you're using the heroku accounts plugin (https://github.com/ddollar/heroku-accounts) to switch between multiple heroku accounts it sets up a ssh host entry (in .ssh/config) per account so you can use different ssh keys. So instead of using git@heroku.com:appname.git as the repo it uses git@heroku.<account>:appname.git so it loads the correct SSH key from the ssh config.

This pull request adds the ability to optionally specify a 'repo' node in the heroku.yml which uses the account in the repo url.

eg;

development: 
  app: myapp
  repo: git@heroku.<account>:<appname>.git
