### PR TITLE
Fix deploy:force

### DIFF
--- a/lib/heroku_san/tasks.rb
+++ b/lib/heroku_san/tasks.rb
@@ -219,7 +219,7 @@ namespace :heroku do
     desc "Force-pushes the given commit, migrates and restarts (default: HEAD)"
     task :force, [:commit] => [:before_deploy] do |t, args|
       each_heroku_app do |stage|
-        stage.deploy(args.merge(:force => true))
+        stage.deploy({:force => true}.merge(args))
       end
       Rake::Task[:after_deploy].execute
     end


### PR DESCRIPTION
After upgrading from Rails 3.1 => 3.2, none of my force deploys seemed to work.  I noticed that the force option was never getting passed into Stage.  It seems that Rake might have frozen the args array it passes to Rake Tasks, so merging force into the args was silently failing.

This fixes the problem by merging the args INTO a new hash, with force set to true
