### PR TITLE
Skip `rake db:migrate` when using Mongoid on `rake heroku:deploy`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ tmp
 .idea/**
 Gemfile.lock
 *.swp
+.rvmrc
+*.sublime*

--- a/lib/heroku_san/deploy/rails.rb
+++ b/lib/heroku_san/deploy/rails.rb
@@ -6,7 +6,7 @@ module HerokuSan
       def deploy
         # TODO: Add announce/logger
         super
-        if Gem.available?('mongoid')
+        if Gem::Specification::find_by_name('mongoid')
           @stage.restart
         else
           @stage.rake('db:migrate')


### PR DESCRIPTION
As `rake db:migrate` does not actually perform any action within Mongoid, this becomes problematic using `heroku_san` for deployments. This causes the `deploy` task to never exit, and run in a continuous loop. The code simply checks if the gem specification includes Mongoid, and skips the call to `rake db:migrate`
