### PR TITLE
Use full path to require railtie

### DIFF
--- a/lib/heroku_san.rb
+++ b/lib/heroku_san.rb
@@ -1,4 +1,4 @@
-require 'railtie' if defined?(Rails) && Rails::VERSION::MAJOR >= 3
+require File.join(File.dirname(__FILE__), 'railtie.rb') if defined?(Rails) && Rails::VERSION::MAJOR >= 3
 require 'git'
 require 'heroku_san/stage'
 require 'heroku_san/project'


### PR DESCRIPTION
require 'railtie' is not loading correct file when other gems exist  earlier in load path that contain their own railtie.rb

Originally covered in issue 111
https://github.com/fastestforward/heroku_san/issues/111
