### PR TITLE
pushes HEAD if tag pattern matching fails

### DIFF
--- a/lib/git.rb
+++ b/lib/git.rb
@@ -2,6 +2,8 @@ require 'rake'
 require 'rake/dsl_definition'
 
 module Git
+  class NoTagFoundError < Exception; end
+
   include Rake::DSL
   
   def git_clone(repos, dir)
@@ -34,7 +36,7 @@ module Git
 
   def git_tag(glob)
     return nil if glob.nil?
-    %x{git tag -l '#{glob}'}.split("\n").last
+    %x{git tag -l '#{glob}'}.split("\n").last || (raise NoTagFoundError, "No tag found [#{glob}]")
   end
   
   def git_revision(repo)

--- a/spec/git_spec.rb
+++ b/spec/git_spec.rb
@@ -32,11 +32,13 @@ describe GitTest do
       subject.should_receive("`").with("git tag -l 'pattern*'") { "x\n\y\n\z\n" }
       subject.git_tag('pattern*').should == "z"
     end
-    it "returns nil if no tags match the pattern" do
+    it "raises exception if no tags match the pattern" do
       subject.should_receive("`").with("git tag -l 'pattern*'") { "\n" }
-      subject.git_tag('pattern*').should == nil
+      expect {
+        subject.git_tag('pattern*')
+      }.to raise_error(Git::NoTagFoundError)
     end
-    it "returns nil for a nil tag" do
+    it "returns nil for a nil glob" do
       subject.should_not_receive("`").with("git tag -l ''") { "\n" }
       subject.git_tag(nil).should == nil
     end

--- a/spec/heroku_san/stage_spec.rb
+++ b/spec/heroku_san/stage_spec.rb
@@ -79,7 +79,8 @@ describe HerokuSan::Stage do
 
   describe "#push" do
     it "deploys to heroku" do
-      subject.should_receive(:git_push).with(git_parsed_tag(subject.tag), subject.repo, [])
+      subject.should_receive(:git_parsed_tag).with(nil) {'tag'}
+      subject.should_receive(:git_push).with('tag', subject.repo, [])
       subject.push
     end
     
@@ -89,7 +90,8 @@ describe HerokuSan::Stage do
     end
     
     it "deploys with --force" do
-      subject.should_receive(:git_push).with(git_parsed_tag(subject.tag), subject.repo, %w[--force])
+      subject.should_receive(:git_parsed_tag).with(nil) {'tag'}
+      subject.should_receive(:git_push).with('tag', subject.repo, %w[--force])
       subject.push(nil, :force)
     end
     


### PR DESCRIPTION
It would be better to fail with a message stating that no tag was found to prevent pushing HEAD to production (or another env).
