### PR TITLE
Update lib/heroku_san/stage.rb

### DIFF
--- a/lib/heroku_san/stage.rb
+++ b/lib/heroku_san/stage.rb
@@ -49,6 +49,7 @@ module HerokuSan
     end
     
     def push(sha = nil, force = false)
+      (sha = sha + "^{commit}") if sha
       sha ||= git_parsed_tag(tag)
       git_push(sha, repo, force ? %w[--force] : [])
     end


### PR DESCRIPTION
A tag can be used as the sha, and a commit can be used if the ref is peeled back into
a commit using '^{commit}'

also:
"d9e226c65fc04aea9c7fe1adce771b480688c206^{commit}^{commit}" 
  == d9e226c65fc04aea9c7fe1adce771b480688c206
