### PR TITLE
Removing whitespaces in heroku.yml template

### DIFF
--- a/lib/templates/heroku.example.yml
+++ b/lib/templates/heroku.example.yml
@@ -1,6 +1,6 @@
 #
 # Format:
-# 
+#
 # <stage name>:
 #   app: <Heroku app name>
 #   stack: <Heroku stack, optional>
@@ -9,7 +9,8 @@
 #   config:
 #     - <Heroku config:var name>: <Heroku config:var value>
 #
-production: 
+
+production:
   app: awesomeapp
   stack: bamboo-ree-1.8.7
   tag: production/*
@@ -28,6 +29,6 @@ staging:
     - logging:basic
     - scheduler:standard
 
-demo: 
+demo:
   app: awesomeapp-demo
   config: *default


### PR DESCRIPTION
Hi,

This is a very minor PR, more a pet peeve of mine. Right now when you run the generator it creates a file with trailing whitespaces, which can go against coding convention of a lot of projects. No big deal but eh, still worth fixing.

Anyways, thanks for the good gem!
