### PR TITLE
 Exit code is getting over written by ensure - and is not being forwarded to the controlling shell.

### DIFF
--- a/lib/git.rb
+++ b/lib/git.rb
@@ -21,7 +21,9 @@ module Git
       sh "git update-ref refs/heroku_san/deploy #{commit}"
       sh "git push #{repo} #{options.join(' ')} refs/heroku_san/deploy:refs/heads/master"
     ensure
+      exitstatus = $?.exitstatus # shell script failure code
       sh "git update-ref -d refs/heroku_san/deploy"
+      exit(exitstatus) 
     end
   end
   


### PR DESCRIPTION
cause exit failure code to be passed through without overwriting it

for issue #123 
