### PR TITLE
Fix broken auto_tagger example

### DIFF
--- a/examples/auto_tagger.rake
+++ b/examples/auto_tagger.rake
@@ -33,7 +33,7 @@ end
 
 task :after_deploy do
   each_heroku_app do |stage|
-    create_and_push(stage.name, stage.revision)
+    create_and_push(stage.name, stage.revision.split.first)
   end
   Rake::Task['autotag:list'].invoke
 end


### PR DESCRIPTION
In auto_tagger.rake stage.revision returns both the sha and the named
ref. This causes git update-ref to fail. Passing only the sha portion of
stage.revision to create_and_push resolves the issue.

Here is the error that I received:

```
cd "/Users/john/Projects/tan-expedite" && git fetch origin refs/tags/*:refs/tags/*
cd "/Users/john/Projects/tan-expedite" && git update-ref refs/tags/staging/20130309015938 18f8e4c89122ed087884a69dc8e9bfa8085eef77 tags/ci/20130309013517
error: unable to resolve reference refs/tags/staging/20130309015938: No such file or directory
fatal: Cannot lock the ref 'refs/tags/staging/20130309015938'.
rake aborted!
AutoTagger::Git::Repo::GitCommandFailedError
/Users/john/Projects/tan-expedite/lib/tasks/heroku.rake:6:in `create_and_push'
/Users/john/Projects/tan-expedite/lib/tasks/heroku.rake:18:in `block (2 levels) in <top (required)>'
/Users/john/Projects/tan-expedite/lib/tasks/heroku.rake:17:in `block in <top (required)>'
Tasks: TOP => deploy => heroku:deploy
(See full trace by running task with --trace)
```
