### PR TITLE
Fix broken config_repo option

### DIFF
--- a/lib/heroku_san/parser.rb
+++ b/lib/heroku_san/parser.rb
@@ -5,8 +5,8 @@ module HerokuSan
     def parse(parseable)
       @settings = parse_yaml(parseable.config_file)
       convert_from_heroku_san_format
-      each_setting_has_a_config_section
       parseable.external_configuration = @settings.delete 'config_repo'
+      each_setting_has_a_config_section
       parseable.configuration = @settings
 
     end


### PR DESCRIPTION
The config_repo needs to be removed from settings before calling
each_setting_has_a_config_setting.

This fixes the below issue:

```
rake -T --trace
rake aborted!
string not matched
/Users/john/.rbenv/versions/1.9.3-p327/lib/ruby/gems/1.9.1/gems/heroku_san-4.2.5/lib/heroku_san/parser.rb:23:in `[]='
/Users/john/.rbenv/versions/1.9.3-p327/lib/ruby/gems/1.9.1/gems/heroku_san-4.2.5/lib/heroku_san/parser.rb:23:in `block in each_setting_has_a_config_section'
/Users/john/.rbenv/versions/1.9.3-p327/lib/ruby/gems/1.9.1/gems/heroku_san-4.2.5/lib/heroku_san/parser.rb:21:in `each'
/Users/john/.rbenv/versions/1.9.3-p327/lib/ruby/gems/1.9.1/gems/heroku_san-4.2.5/lib/heroku_san/parser.rb:21:in `each_setting_has_a_config_section'
/Users/john/.rbenv/versions/1.9.3-p327/lib/ruby/gems/1.9.1/gems/heroku_san-4.2.5/lib/heroku_san/parser.rb:8:in `parse'
/Users/john/.rbenv/versions/1.9.3-p327/lib/ruby/gems/1.9.1/gems/heroku_san-4.2.5/lib/heroku_san/configuration.rb:17:in `parse'
/Users/john/.rbenv/versions/1.9.3-p327/lib/ruby/gems/1.9.1/gems/heroku_san-4.2.5/lib/heroku_san/configuration.rb:21:in `stages'
/Users/john/.rbenv/versions/1.9.3-p327/lib/ruby/gems/1.9.1/gems/heroku_san-4.2.5/lib/heroku_san/project.rb:15:in `stages'
/Users/john/.rbenv/versions/1.9.3-p327/lib/ruby/gems/1.9.1/gems/heroku_san-4.2.5/lib/heroku_san/project.rb:27:in `all'
/Users/john/.rbenv/versions/1.9.3-p327/lib/ruby/gems/1.9.1/gems/heroku_san-4.2.5/lib/heroku_san/tasks.rb:12:in `<top (required)>'
```
