### PR TITLE
Do not override custom stage config

### DIFF
--- a/lib/heroku_san/configuration.rb
+++ b/lib/heroku_san/configuration.rb
@@ -20,7 +20,12 @@ module HerokuSan
     def stages
       configured? or parse
       configuration.inject({}) do |stages, (stage, settings)|
-        stages[stage] = HerokuSan::Stage.new(stage, settings.merge('deploy' => (options[:deploy]||options['deploy'])))
+        deploy_strategy = if settings.keys.include?('deploy')
+          eval(settings['deploy'])
+        else
+          options[:deploy]||options['deploy']
+        end
+        stages[stage] = HerokuSan::Stage.new(stage, settings.merge('deploy' => deploy_strategy))
         stages
       end
     end

--- a/spec/heroku_san/configuration_spec.rb
+++ b/spec/heroku_san/configuration_spec.rb
@@ -20,6 +20,14 @@ describe HerokuSan::Configuration do
           'production' => HerokuSan::Stage.new('production', 'deploy' => HerokuSan::Deploy::Base)
       }
     end
+
+    it "does NOT override custom settings" do
+      configurable.options = {'deploy' => HerokuSan::Deploy::Rails}
+      configuration.configuration = {'production' => { 'deploy' => 'HerokuSan::Deploy::Base' }}
+      configuration.stages.should == {
+          'production' => HerokuSan::Stage.new('production', 'deploy' => HerokuSan::Deploy::Base)
+      }
+    end
   end
 
   describe "#generate_config" do


### PR DESCRIPTION
The deploy strategy defined for the project is always overriding the configuration of specific stages. This doesn't let one choose different strategies for different stages.
