### PR TITLE
Fix detection of installed addons

### DIFF
--- a/lib/heroku_san/stage.rb
+++ b/lib/heroku_san/stage.rb
@@ -43,7 +43,7 @@ module HerokuSan
     end
 
     def addons
-      (@options['addons'] ||= []).flatten
+      (@options['addons'] ||= []).map{|addon, level| "#{addon}:#{level}"}
     end
     
     def run(command, args = nil)


### PR DESCRIPTION
Looks like something changed in the Heroku gem.

Your detection of existing addons resulted in a list looking like:

``` yaml
- 'honeybadger'
- 'development'
- 'papertrial'
- 'choklad'
```

when you needed:

``` yaml
- 'honeybadger:development'
- 'papertrail:choklad'
```
