### PR TITLE
Allow for an ignore "Defaults" block in the YAML

### DIFF
--- a/lib/heroku_san/parser.rb
+++ b/lib/heroku_san/parser.rb
@@ -6,6 +6,7 @@ module HerokuSan
     attr_accessor :settings
     def parse(parseable)
       @settings = parse_yaml(parseable.config_file)
+      @settings.delete 'defaults'
       convert_from_heroku_san_format
       parseable.external_configuration = @settings.delete 'config_repo'
       each_setting_has_a_config_section

--- a/lib/heroku_san/stage.rb
+++ b/lib/heroku_san/stage.rb
@@ -43,7 +43,7 @@ module HerokuSan
     end
 
     def addons
-      (@options['addons'] ||= []).flatten
+      (@options['addons'] ||= []).map{|addon, level| "#{addon}:#{level}"}
     end
     
     def run(command, args = nil)


### PR DESCRIPTION
I'm managing multiple apps, and I want to be DRY, so I need a place to define some YAML nodes to then reference:

``` yaml
defaults:                      
  addons: &addons         
    pgbackups: plus            
    sendgrid: starter          
    papertrail: choklad        
    heroku-postgresql: dev     
  config: &config         
    BUNDLE_WITHOUT: "development:test"
    AWS_ACCESS_KEY_ID: 'key'
    AWS_SECRET_ACCESS_KEY: 'secret'

app1:
  stack: cedar
  app: awesome-app-the-first
  addons:
    <<: *addons
  config: 
    <<: *config
    DOMAIN: "awesome-app-the-first.herokuapp.com"
    AWS_BUCKET: 'bucket'
```
