### PR TITLE
Fix for broken after_deploy task

### DIFF
--- a/lib/heroku_san/tasks.rb
+++ b/lib/heroku_san/tasks.rb
@@ -208,7 +208,7 @@ namespace :heroku do
     each_heroku_app do |stage|
       stage.deploy(args.commit)
     end
-    Rake::Task[:after_deploy].execute
+    Rake::Task[:after_deploy].invoke
   end
 
   namespace :deploy do
@@ -217,7 +217,7 @@ namespace :heroku do
       each_heroku_app do |stage|
         stage.deploy(args.commit, :force)
       end
-      Rake::Task[:after_deploy].execute
+      Rake::Task[:after_deploy].invoke
     end
 
     desc "Callback before deploys"


### PR DESCRIPTION
Rake::Task#execute does not run prerequisites; #invoke does.  The after_deploy task is set up explicitly as a prerequisite, so #execute will not run it.  This fixes the issue by calling #invoke.
