### PR TITLE
Adds 'json' as a runtime dependency under MRI 1.8

### DIFF
--- a/heroku_san.gemspec
+++ b/heroku_san.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |s|
     s.add_dependency(%q<cucumber>)
   end
   
-  if RUBY_VERSION < '1.8'
+  if RUBY_VERSION < '1.9'
     s.add_runtime_dependency(%q<json>)
   end
 end


### PR DESCRIPTION
This should resolve failing CI builds.
