### PR TITLE
Fix issues with running Ruby 2.0.0 and using Heroku Toolbelt

### DIFF
--- a/features/shell_execution.feature
+++ b/features/shell_execution.feature
@@ -1,0 +1,47 @@
+@slow_process @announce-cmd
+Feature: heroku_san can shell out to heroku without errors
+
+  Scenario: Bundling a ruby 2.0 project
+    Given I run `mkdir -p ruby2test`
+    And I cd to "ruby2test"
+    And I write to "Gemfile" with:
+    """
+      source "https://rubygems.org"
+      ruby '2.0.0'
+      gem 'heroku_san', :path => '../../../.'
+    """
+
+    And I write to "get_heroku_version.rb" with:
+    """
+      #!/usr/bin/env ruby
+
+      puts ENV['RUBY_VERSION']
+
+      ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __FILE__)
+
+      require 'bundler/setup'
+
+      require 'heroku_san'
+
+      api = HerokuSan::API.new
+
+      api.sh('cool_app', 'version')
+    """
+    And I write to "run_in_ruby_2.sh" with:
+    """
+    #!/usr/bin/env bash
+
+    [[ -s "$HOME/.rvm/scripts/rvm" ]] && source "$HOME/.rvm/scripts/rvm"
+
+    rvm use 2.0.0
+    bundle install
+
+    ruby get_heroku_version.rb
+    """
+    And I run `chmod +x run_in_ruby_2.sh`
+    And I cleanly run `./run_in_ruby_2.sh`
+    Then the output should contain "heroku-toolbelt"
+    # Fail if we see "Your Ruby version is 1.9.3, but your Gemfile specified 2.0.0"
+    Then the output should not contain "Your Ruby version"
+    Then the output should not contain "your Gemfile specified"
+

--- a/features/step_definitions/remote_steps.rb
+++ b/features/step_definitions/remote_steps.rb
@@ -87,6 +87,10 @@ When /^I run bundle install$/ do
   run_clean "bundle install"
 end
 
+When /^I cleanly run `([^`]*)`$/ do |cmd|
+  run_clean(cmd)
+end
+
 Then /^rake reports that the heroku: tasks are available$/ do
   output = run_clean 'rake -T heroku:'
   assert_partial_output 'rake heroku:apps', output

--- a/lib/heroku_san/api.rb
+++ b/lib/heroku_san/api.rb
@@ -16,7 +16,7 @@ module HerokuSan
       show_command = cmd.join(' ')
       $stderr.puts show_command if @debug
 
-      ok = system "heroku", *cmd
+      ok = Bundler.with_clean_env { system "heroku", *cmd }
 
       status = $?
       ok or fail "Command failed with status (#{status.exitstatus}): [heroku #{show_command}]"
@@ -35,13 +35,13 @@ module HerokuSan
     private
 
     def auth_token
-      ENV['HEROKU_API_KEY'] || `heroku auth:token`.chomp
+      ENV['HEROKU_API_KEY'] || Bundler.with_clean_env { `heroku auth:token`.chomp }
     rescue Errno::ENOENT
       nil
     end
 
     def preflight_check_for_cli
-      raise "The Heroku Toolbelt is required for this action. http://toolbelt.heroku.com" if system('heroku version') == nil
+      raise "The Heroku Toolbelt is required for this action. http://toolbelt.heroku.com" if Bundler.with_clean_env { system('heroku version') == nil }
     end
   end
 end


### PR DESCRIPTION
The issue was that bundle sets ENV['RUBYOPT'] after it has been
loaded, which causes any subprocesses that get spawned
to be confused. The Heroku Toolbelt installs with its own Ruby 1.9.3
binary that lives in /usr/local/heroku/ruby/bin/ruby, so when the
'heroku' script is executed with Ruby 2.0 files in the include path
from bundler, it freaks out.

If you spawn the processes using the incantation
"Bundler.with_clean_env", the RUBYOPT will be temporarily restored.

See for more info:
http://pivotallabs.com/service-oriented-foreman/

We wrote a cucumber test (shell_execution.feature) that exposes
the problem, but it requires that you have the Heroku Toolbelt
installed (not the gem) as well as RVM and Ruby 2.0.

This should fix #151, #150, #146, #138, #133, and #118
